### PR TITLE
✨ Add KubeStellar Console to Kubernetes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ Faster, prettier, smarter replacements for the Unix utilities you use every day.
 
 - [k9s](https://github.com/derailed/k9s) - TUI for managing Kubernetes clusters. `Go`
 - [kdash](https://github.com/kdash-rs/kdash) - A simple and fast dashboard for Kubernetes. `Rust`
+- [kubestellar-console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with AI-powered operations and real-time observability. `Go`
 - [lfk](https://github.com/janosmiko/lfk) - Yazi-inspired, vim-like keyboard focused Lightning Fast Kubernetes navigator. `Go`
 
 **[⬆ back to top](#contents)**


### PR DESCRIPTION
## What

Add [KubeStellar Console](https://github.com/kubestellar/console) to the Kubernetes section.

## About

KubeStellar Console is a multi-cluster Kubernetes dashboard written in Go with a React frontend. Features:

- Multi-cluster management across edge and cloud
- AI-powered operations via built-in MCP server
- Real-time WebSocket streaming
- 50+ dashboard cards for pods, deployments, services, and more
- CNCF Sandbox project

Follows the existing format: `- [name](url) - Description. \`Language\``