### PR TITLE
Add microNeo to Text Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Faster, prettier, smarter replacements for the Unix utilities you use every day.
 - [kakoune](https://github.com/mawww/kakoune) - Modal editor with multi-selection first design. `C++`
 - [Lapce](https://github.com/lapce/lapce) - A lightning-fast and powerful code editor with native GUI. `Rust`
 - [micro](https://github.com/micro-editor/micro) - A modern and intuitive terminal-based text editor, replaces nano. `Go`
+- [microNeo](https://github.com/sollawen/microNeo) - A fork of Micro with in-place Markdown rendering — view and edit in the same window. `Go`
 - [neovim](https://github.com/neovim/neovim) - Vim-fork focused on extensibility and usability with Lua plugin system. `C`
 - [ox](https://github.com/curlpipe/ox) - An independent terminal text editor, simple and practical. `Rust`
 - [zed](https://github.com/zed-industries/zed) - A high-performance multiplayer code editor from the creators of Atom. `Rust`


### PR DESCRIPTION
microNeo is a fork of Micro that adds in-place Markdown rendering — open a .md file and see it rendered immediately, click anywhere to edit. No split panes.

The only terminal editor that renders and edits Markdown in the same window.

Built in Go, single binary, one-line install.

https://github.com/sollawen/microNeo

Thanks!