### PR TITLE
Add datadiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Faster, prettier, smarter replacements for the Unix utilities you use every day.
 
 - [csvlens](https://github.com/YS-L/csvlens) - A TUI CSV file viewer, like less but made for tabular data. `Rust`
 - [dasel](https://github.com/tomwright/dasel) - Query and modify JSON, YAML, TOML, and XML from the command line. `Go`
+- [datadiff](https://github.com/cloudroad-io/datadiff) - A semantic diff for structured data files — shows what changed in JSON, YAML, CSV, TOML, and XML by meaning, not by lines. `Rust`
 - [dyff](https://github.com/homeport/dyff) - A diff tool for YAML files with semantic awareness. `Go`
 - [fx](https://github.com/antonmedv/fx) - Terminal JSON viewer and processor with interactive mode. `Go`
 - [gron](https://github.com/tomnomnom/gron) - Make JSON greppable by flattening it to discrete assignments. `Go`

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Faster, prettier, smarter replacements for the Unix utilities you use every day.
 
 - [csvlens](https://github.com/YS-L/csvlens) - A TUI CSV file viewer, like less but made for tabular data. `Rust`
 - [dasel](https://github.com/tomwright/dasel) - Query and modify JSON, YAML, TOML, and XML from the command line. `Go`
-- [datadiff](https://github.com/cloudroad-io/datadiff) - A semantic diff for structured data files — shows what changed in JSON, YAML, CSV, TOML, and XML by meaning, not by lines. `Rust`
+- [datadiff](https://github.com/dimanovikov/datadiff) - A semantic diff for structured data files — shows what changed in JSON, YAML, CSV, TOML, and XML by meaning, not by lines. `Rust`
 - [dyff](https://github.com/homeport/dyff) - A diff tool for YAML files with semantic awareness. `Go`
 - [fx](https://github.com/antonmedv/fx) - Terminal JSON viewer and processor with interactive mode. `Go`
 - [gron](https://github.com/tomnomnom/gron) - Make JSON greppable by flattening it to discrete assignments. `Go`


### PR DESCRIPTION
## Tool Submission

**Tool name:** datadiff
**Repository URL:** https://github.com/dimanovikov/datadiff
**What classic tool does it replace?** `diff` (for structured data files; complements dyff, which covers YAML only)
**Language:** Rust

## Why is it awesome?

datadiff is a semantic diff for structured data files. Unlike line-based `diff`, it compares JSON, YAML, CSV, TOML, and XML by meaning: it parses both files and reports changes in terms of the data model (added/removed/changed keys, array elements, cells), so reformatting, key reordering, and whitespace changes produce no noise. It is essentially a wider-scope sibling of dyff (which is YAML-only and already in this section): same semantic-diff idea, but across five formats. Pre-built binaries for Linux/macOS/Windows are published with the v0.2.0 release.

## Checklist

- [ ] Tool has **100+ GitHub stars** (new project, not yet at 100 stars — submitting for your consideration per the quality criteria; feel free to close if this is a hard requirement)
- [x] Tool has been **committed to in the last 12 months**
- [x] I have **tested this tool locally** or used it meaningfully
- [x] Entry follows the **required format**: `[name](url) - Description. Replaces \`classic\`. \`Language\``
- [x] Entry is in **alphabetical order** within its section
- [x] This PR contains **only one tool**
- [x] I have disclosed if I am the **author or maintainer** of this tool — disclosure: I am the author of datadiff (dimanovikov).