### PR TITLE
feat: add ferrisfetch to System Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Faster, prettier, smarter replacements for the Unix utilities you use every day.
 - [bottom](https://github.com/ClementTsang/bottom) - A cross-platform graphical process/system monitor. `Rust`
 - [btop](https://github.com/aristocratos/btop) - A resource monitor with beautiful TUI and extensive features. `C++`
 - [fastfetch](https://github.com/fastfetch-cli/fastfetch) - A fast system information tool, neofetch replacement. `C`
-- [ferrisfetch](https://github.com/Kk376/ferrisfetch) - Fast and lightweight system information tool with Ferris ASCII art. Replaces `neofetch`. `Rust`
+- [ferrisfetch](https://github.com/kk376/ferrisfetch) - Fast and lightweight system information tool with Ferris ASCII art. Replaces `neofetch`. `Rust`
 - [glances](https://github.com/nicolargo/glances) - An eye on your system with a top/htop alternative and web mode. `Python`
 - [gotop](https://github.com/xxxserxxx/gotop) - Terminal-based graphical activity monitor. `Go`
 - [kmon](https://github.com/orhun/kmon) - Linux Kernel Manager and Activity Monitor. `Rust`

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Faster, prettier, smarter replacements for the Unix utilities you use every day.
 - [bottom](https://github.com/ClementTsang/bottom) - A cross-platform graphical process/system monitor. `Rust`
 - [btop](https://github.com/aristocratos/btop) - A resource monitor with beautiful TUI and extensive features. `C++`
 - [fastfetch](https://github.com/fastfetch-cli/fastfetch) - A fast system information tool, neofetch replacement. `C`
+- [ferrisfetch](https://github.com/Kk376/ferrisfetch) - Fast and lightweight system information tool with Ferris ASCII art. Replaces `neofetch`. `Rust`
 - [glances](https://github.com/nicolargo/glances) - An eye on your system with a top/htop alternative and web mode. `Python`
 - [gotop](https://github.com/xxxserxxx/gotop) - Terminal-based graphical activity monitor. `Go`
 - [kmon](https://github.com/orhun/kmon) - Linux Kernel Manager and Activity Monitor. `Rust`


### PR DESCRIPTION
## Tool Submission

**Tool name:** ferrisfetch
**Repository URL:** https://github.com/kk376/ferrisfetch
**What classic tool does it replace?** neofetch
**Language:** Rust

## Why is it awesome?

FerrisFetch is a fast, lightweight system information fetch tool written in Rust with Ferris ASCII art, modular output sections, and shell completions. Available on crates.io, Ubuntu Launchpad PPA, KISS Linux, and Termux.

## Checklist

- [ ] Tool has **100+ GitHub stars**
- [x] Tool has been **committed to in the last 12 months**
- [x] I have **tested this tool locally** or used it meaningfully
- [x] Entry follows the **required format**: `[name](url) - Description. Replaces \`classic\`. \`Language\``
- [x] Entry is in **alphabetical order** within its section
- [x] This PR contains **only one tool**
- [x] I have disclosed if I am the **author or maintainer** of this tool