### PR TITLE
fix: restore the star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,7 +730,7 @@ Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=thegdsks/awesome-modern-cli&type=Date)](https://star-history.com/#thegdsks/awesome-modern-cli&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=thegdsks/awesome-modern-cli&type=Date)](https://star-history.dera.page/#thegdsks/awesome-modern-cli&type=Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart is currently broken and no longer renders correctly. Update its links so the repository's star history is available again.