### PR TITLE
feat: add Network Doctor to Network Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ Faster, prettier, smarter replacements for the Unix utilities you use every day.
 - [gping](https://github.com/orf/gping) - Ping, but with a graph. `Rust`
 - [miniserve](https://github.com/svenstaro/miniserve) - Serve files over HTTP from the terminal with a single command. `Rust`
 - [netscanner](https://github.com/Chleba/netscanner) - A TUI network scanner. `Rust`
+- [Network Doctor](https://github.com/heymaikol/network-doctor) - Diagnoses interface, DNS, TCP, TLS, HTTP, proxy, and path MTU failures with actionable fixes. Replaces manual `ping`, `dig`, and `curl` troubleshooting. `Go`
 - [nibble](https://github.com/backendsystems/nibble) - A fast local network scanner with hardware vendor detection and service names. `Go`
 - [sniffnet](https://github.com/GyulyVGC/sniffnet) - Monitor your network traffic easily with a cross-platform TUI. `Rust`
 - [termshark](https://github.com/gcla/termshark) - A terminal UI for tshark, inspired by Wireshark. `Go`


### PR DESCRIPTION
## Tool Submission

**Tool name:** Network Doctor
**Repository URL:** https://github.com/heymaikol/network-doctor
**What classic tool does it replace?** Manual troubleshooting with `ping`, `dig`, and `curl`
**Language:** Go

## Why is it awesome?

Network Doctor diagnoses connectivity failures layer by layer and gives plain-language fixes. It uses unprivileged probes and runs on Linux, macOS, and Windows.

I am the author and maintainer.

## Checklist

- [x] Tool has **100+ GitHub stars**
- [x] Tool has been **committed to in the last 12 months**
- [x] I have **tested this tool locally** or used it meaningfully
- [x] Entry follows the **required format**: `[name](url) - Description. Replaces \`classic\`. \`Language\``
- [x] Entry is in **alphabetical order** within its section
- [x] This PR contains **only one tool**
- [x] I have disclosed if I am the **author or maintainer** of this tool
