### PR TITLE
fix: three low-risk CI/maintenance fixes

### DIFF
--- a/.github/workflows/awesome-lint.yml
+++ b/.github/workflows/awesome-lint.yml
@@ -1,0 +1,20 @@
+name: Awesome Lint
+
+# main currently fails awesome-lint (295 errors, 13 warnings as of 2026-09-06,
+# mostly trailing `Language` tags on every entry -- see PR #26 for the fix).
+# Until that cleanup lands, this check is informational-only (continue-on-error)
+# so it doesn't block every PR through no fault of the contributor. Once main
+# passes cleanly, remove `continue-on-error` to make this a hard gate.
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  awesome-lint:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run awesome-lint
+        run: npx --yes awesome-lint

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Faster, prettier, smarter replacements for the Unix utilities you use every day.
     <td align="center">
       <a href="https://github.com/ajeetdsouza/zoxide"><b>zoxide</b></a><br>
       <sub>smarter cd</sub><br><br>
-      <a href="https://github.com/ajeetdsouza/zoxide"><img src="https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/contrib/tutorial.webp" width="400" /></a>
+      <a href="https://github.com/ajeetdsouza/zoxide"><img src="https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/contrib/tutorial.gif" width="400" /></a>
     </td>
     <td align="center">
       <a href="https://github.com/sharkdp/hyperfine"><b>hyperfine</b></a><br>

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,9 @@
+# lychee link checker config
+# https://lychee.cli.rs/#/usage/config
+
+# GitHub's stargazers badge link returns a 404 to lychee's bot-like requests
+# even though it resolves fine in a browser. Exclude it to stop the chronic
+# false-positive failures on every push/PR/schedule run.
+exclude = [
+  "^https://github\\.com/thegdsks/awesome-modern-cli/stargazers$",
+]


### PR DESCRIPTION
## Summary

Three independently-diagnosed, low-risk fixes:

1. **Dead zoxide image link** - `contrib/tutorial.webp` no longer exists in `ajeetdsouza/zoxide`; it was renamed to `contrib/tutorial.gif` upstream. Confirmed via curl (webp -> 404, gif -> 200). Updated the README embed.

2. **New `lychee.toml`** - the stargazers badge URL (`.../stargazers`) has failed link-check on nearly every run since July: it 404s to lychee's bot-like request even though it resolves fine in a browser (reproduced this locally, a bare `lychee https://.../stargazers` also 404s). Added an `exclude` regex for that one URL. lychee picks up `lychee.toml` from the repo root automatically, no change needed to `link-check.yml`'s `args`. Verified locally with lychee 0.24.2, the same version lychee-action v2 pins by default: `README.md` now checks clean (0 errors, 1 excluded, down from 1 error before the zoxide fix + this exclusion).

3. **New `awesome-lint.yml` workflow** - there was no automated awesome-lint check, despite the repo caring about compliance (see #26). Added a PR-triggered workflow modeled on `link-check.yml`'s conventions.

   **Note for maintainer:** I ran `npx awesome-lint` against current `main` myself and got **295 errors, 13 warnings** (mostly trailing `` `Language` `` tags on every entry, same root cause as #26). Since main doesn't pass today, I made this workflow `continue-on-error: true` (informational, non-blocking) rather than a hard gate, so it doesn't immediately go red on every future PR through no fault of the contributor. Once #26 (or equivalent cleanup) merges and main passes cleanly, `continue-on-error` should be dropped to make this a real gate. Happy to do that in a follow-up once #26 lands, or flip it now if you'd rather have it blocking immediately.

## Test plan

- [x] `curl -I` confirms `contrib/tutorial.gif` returns 200, old `.webp` path returns 404
- [x] Ran `lychee --config lychee.toml README.md` locally (lychee 0.24.2, matching lychee-action v2's default): 0 errors, stargazers URL shows `[EXCLUDED]`
- [x] Ran `npx awesome-lint` against `main`: 295 errors / 13 warnings (documented above, drove the continue-on-error choice)
- [x] Validated both workflow YAML files with `actionlint`: no issues